### PR TITLE
Build config

### DIFF
--- a/Builder/VirtualBuilder.php
+++ b/Builder/VirtualBuilder.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Massive\Bundle\BuildBundle\Builder;
+
+use Massive\Bundle\BuildBundle\Build\BuilderInterface;
+use Massive\Bundle\BuildBundle\Build\BuilderContext;
+
+/**
+ * A builder which does nothing itself but declares
+ * dependencies on other builders.
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class VirtualBuilder implements BuilderInterface
+{
+    protected $name;
+    protected $dependencies;
+
+    public function __construct($name, $dependencies)
+    {
+        $this->name = $name;
+        $this->dependencies = $dependencies;
+    }
+
+    /**
+     * Return the name for this builder
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Return the dependencies for this builder
+     *
+     * @return array
+     */
+    public function getDependencies()
+    {
+        return $this->dependencies;
+    }
+
+    /**
+     * Execute the build logic
+     */
+    public function build()
+    {
+    }
+
+    /**
+     * Set the builder context
+     *
+     * @param \Massive\Bundle\BuildBundle\Build\BuilderContext
+     */
+    public function setContext(BuilderContext $context)
+    {
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+Changelog
+=========
+
+0.2
+---
+
+- [feature] Allow creation of virtual targets via. configuration
+- [bug] Dependency not found when specifying target (nested dependencies not taken into account)
+
+0.1
+---
+
+- Everything

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,6 +22,19 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('command_class')->defaultValue('Massive\Bundle\BuildBundle\Command\BuildCommand')->end()
+                ->arrayNode('targets')
+                    ->useAttributeAsKey('name')
+                    ->prototype('array')
+                        ->children()
+                            ->arrayNode('dependencies')
+                                ->useAttributeAsKey('key')
+                                ->prototype('array')
+                                    ->prototype('scalar')->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/MassiveBuildExtension.php
+++ b/DependencyInjection/MassiveBuildExtension.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * This is the class that loads and manages your bundle configuration
@@ -25,5 +26,14 @@ class MassiveBuildExtension extends Extension
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+
+        foreach ($config['targets'] as $target => $config) {
+            $dependencies = array_keys($config['dependencies']);
+            $targetDefinition = new Definition('Massive\Bundle\BuildBundle\Builder\VirtualBuilder', array(
+                $target, $dependencies
+            ));
+            $targetDefinition->addTag('massive_build.builder');
+            $container->setDefinition('massive_build.builder.virtual.' . $target, $targetDefinition);
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@ Massive Build Bundle
 The Massive Build Bundle provides a `massive:build` command which runs build
 targets.
 
-Targets are effectively classes which execute arbitary code, and are
-registred in the dependency injection container via. tags. Targets can
-depend on other targets.
+Targets are classes which execute arbitary code, and are registred in the
+dependency injection container via. tags. Targets can depend on other targets.
+
+Virtual targets can be created in you applications configuration file. These 
+virtual targets simply declare depenencies, enabling you to configure custom
+build processes.
 
 The aim of this bundle is to provide an extensible, decoupled, way of building
 software project environments, especially in a development context.
@@ -18,6 +21,33 @@ establish your environment, then this bundle is for you.
 
 *This tool is not mean to replace Make or Ant or Phing. The bundle should only
 be used to execute build steps which are contained in the client application.*
+
+## Defining targets
+
+You can define new build targets in you applications configuration file:
+
+````
+massive_build:
+    targets:
+        main:
+            target_one: ~
+            target_two: ~
+            target_three: ~
+        quick:
+            target_one: ~
+````
+
+The above will allow you to execute:
+
+````
+$ php app/console massive:build main
+````
+
+and:
+
+````
+$ php app/console massive:build quick
+````
 
 ## Creating build classes
 

--- a/Tests/Builder/VirtualBuilderTest.php
+++ b/Tests/Builder/VirtualBuilderTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Massive\Bundle\BuildBundle\Builder;
+
+class VirtualBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    protected $builder;
+
+    public function setUp()
+    {
+        $this->builder = new VirtualBuilder('builder', array('one', 'two', 'three'));
+    }
+
+    public function testBuilder()
+    {
+        $this->assertEquals('builder', $this->builder->getName());
+        $this->assertEquals(array('one', 'two', 'three'), $this->builder->getDependencies());
+    }
+}

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Massive\Bundle\BuildBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyConfigTest\PhpUnit\AbstractConfigurationTestCase;
+use Massive\Bundle\BuildBundle\DependencyInjection\Configuration;
+
+class ConfigurationTest extends AbstractConfigurationTestCase
+{
+    protected function getConfiguration()
+    {
+        return new Configuration();
+    }
+
+    public function testConfiguration()
+    {
+        $this->assertProcessedConfigurationEquals(array(
+            array(
+                'command_class' => 'Foo\Bar',
+                'targets' => array(
+                    'all' => array(
+                        'dependencies' => array(
+                            'foo' => array(), 
+                            'bar' => array(), 
+                            'baz' => array(),
+                        ),
+                    ),
+                ),
+            ),
+        ), array(
+                'command_class' => 'Foo\Bar',
+                'targets' => array(
+                    'all' => array(
+                        'dependencies' => array(
+                            'foo' => array(), 
+                            'bar' => array(),
+                            'baz' => array(),
+                        )
+                    ),
+                ),
+            )
+        );
+    }
+
+    public function testTargetsAsNull()
+    {
+        $this->assertProcessedConfigurationEquals(array(
+            array(
+                'targets' => array(
+                    'all' => array(
+                        'dependencies' => array(
+                            'foo' => null, 
+                            'bar' => null, 
+                            'baz' => null,
+                        ),
+                    ),
+                ),
+            ),
+        ), array(
+                'command_class' => 'Massive\Bundle\BuildBundle\Command\BuildCommand',
+                'targets' => array(
+                    'all' => array(
+                        'dependencies' => array(
+                            'foo' => array(), 
+                            'bar' => array(),
+                            'baz' => array(),
+                        )
+                    ),
+                ),
+            )
+        );
+    }
+}

--- a/Tests/DependencyInjection/MassiveArtBuildExtensionTest.php
+++ b/Tests/DependencyInjection/MassiveArtBuildExtensionTest.php
@@ -19,4 +19,30 @@ class MassiveArtBuildExtensionTest extends AbstractExtensionTestCase
         $this->load();
         $this->assertContainerBuilderHasService('massive_build.build.registry');
     }
+
+    public function testLoadWithTargets()
+    {
+        $this->load(array(
+            'targets' => array(
+                'all' => array(
+                    'dependencies' => array('one' => array(), 'two' => array(), 'three' => array())
+                )
+            ),
+        ));
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'massive_build.builder.virtual.all',
+            'massive_build.builder'
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'massive_build.builder.virtual.all',
+            0, 'all'
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'massive_build.builder.virtual.all',
+            1, array('one', 'two', 'three')
+        );
+    }
 }


### PR DESCRIPTION
ADding possiblity to add build targets in the application configuration, e.g.

```
targets:
    main:
        database: { destroy: true }
    no-translations: { phpcr: ~, user: ~ ]
```

They are created as "virtual" builders and so can be executed as builders:

``` bash
$ php app/console massive:build main
```
