### PR TITLE
do not indent message when decoration is disabled

### DIFF
--- a/Console/MassiveOutputFormatter.php
+++ b/Console/MassiveOutputFormatter.php
@@ -30,6 +30,10 @@ class MassiveOutputFormatter extends OutputFormatter
     public function format($message)
     {
         $out = parent::format($message);
+        if (!$this->isDecorated()) {
+            return $out;
+        }
+
         $lines = explode("\n", $out);
         foreach ($lines as &$line) {
             $line = str_repeat('    ', $this->indentLevel) . $line;

--- a/Tests/Console/MassiveOutputFormatterTest.php
+++ b/Tests/Console/MassiveOutputFormatterTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Massive\Bundle\BuildBundle\Tests\Console;
+
+use Massive\Bundle\BuildBundle\Console\MassiveOutputFormatter;
+
+class MassiveOutputFormatterTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @param string $message
+     * @param int    $indent
+     * @param string $expected
+     *
+     * @dataProvider getDecorationDataProvider
+     */
+    public function testThatOutputWillBeDecorated($message, $indent, $expected)
+    {
+        $formatter = new MassiveOutputFormatter(true);
+        $formatter->setIndentLevel($indent);
+        $result = $formatter->format($message);
+        $this->assertEquals($expected, $result);
+
+    }
+
+    public function getDecorationDataProvider()
+    {
+        return [
+            ['Some string', 0, 'Some string'],
+            ['Some string', 1, '    Some string'],
+            ['Some string', 2, '        Some string'],
+        ];
+    }
+
+    /**
+     * @param string $message
+     * @param int    $indent
+     *
+     * @dataProvider getNonDecorationDataProvider
+     */
+    public function testThatOutputWillNotBeDecorated($message, $indent)
+    {
+        $formatter = new MassiveOutputFormatter(false);
+        $formatter->setIndentLevel($indent);
+        $result = $formatter->format($message);
+        $this->assertEquals($message, $result);
+    }
+
+    public function getNonDecorationDataProvider()
+    {
+        return [
+            ['Some string', 0],
+            ['Some string', 1],
+            ['Some string', 2],
+        ];
+    }
+}


### PR DESCRIPTION
fixes PHP warnings when calculating the length of undecorated message for the progress bar
see https://github.com/sulu/sulu/issues/3854