### PR TITLE
Keeping the exit code of jobs

### DIFF
--- a/Build/BuilderInterface.php
+++ b/Build/BuilderInterface.php
@@ -25,6 +25,8 @@ interface BuilderInterface
 
     /**
      * Execute the build logic
+     *
+     * @return int|null
      */
     public function build();
 

--- a/Command/BuildCommand.php
+++ b/Command/BuildCommand.php
@@ -82,7 +82,7 @@ EOT
 
         $this->addArgument('target', InputArgument::OPTIONAL, 'Target to build', null);
         $this->addOption('nodeps', 'D', InputOption::VALUE_NONE, 'Ignore dependencies');
-        $this->addOption('exitCode', 'e', InputOption::VALUE_NONE, 'Keep the exit code of a job if it fails');
+        $this->addOption('keep-exit-code', '-k', InputOption::VALUE_NONE, 'Keep the exit code of a job if it fails');
     }
 
     /**
@@ -115,7 +115,7 @@ EOT
             if (!$this->question->ask($input, $output, $question)) {
                 $this->output->writeln('Bye!');
 
-                return;
+                return 0;
             }
         }
 
@@ -126,7 +126,7 @@ EOT
 
         $this->output->writeln(sprintf('<info>Done (%ss)</info>', number_format($end - $start, 2)));
 
-        if($input->getOption('exitCode') && $exitCode !== 0) {
+        if($exitCode !== 0 && $input->getOption('keep-exit-code')) {
             return $exitCode;
         }
         return 0;

--- a/Tests/Command/BuildCommandTest.php
+++ b/Tests/Command/BuildCommandTest.php
@@ -75,6 +75,26 @@ class BuildCommandTest extends BaseTestCase
         $this->assertEquals(0, $res);
     }
 
+    public function testBuildTargetThatFails()
+    {
+        $this->buildRegistry->getBuilders('Builder 1')->willReturn(array(
+            $this->builder1->reveal(),
+            $this->builder2->reveal()
+        ));
+
+        $this->builder2->setContainer($this->container)->shouldBeCalled();
+        $this->builder1->setContext(Argument::type('Massive\Bundle\BuildBundle\Build\BuilderContext'))
+                       ->shouldBeCalled();
+        $this->builder2->setContext(Argument::type('Massive\Bundle\BuildBundle\Build\BuilderContext'))
+                       ->shouldBeCalled();
+
+        $this->builder1->build()->shouldBeCalled()->willReturn(1);
+        $this->builder2->build()->shouldBeCalled();
+
+        $res = $this->execute(array('target' => 'Builder 1', '--exitCode' => true), array());
+        $this->assertEquals(1, $res);
+    }
+
     public function testBuildNotTarget()
     {
         $this->buildRegistry->getBuilders(null)->willReturn(array(

--- a/Tests/Command/BuildCommandTest.php
+++ b/Tests/Command/BuildCommandTest.php
@@ -91,8 +91,8 @@ class BuildCommandTest extends BaseTestCase
         $this->builder1->build()->shouldBeCalled()->willReturn(1);
         $this->builder2->build()->shouldBeCalled();
 
-        $res = $this->execute(array('target' => 'Builder 1', '--exitCode' => true), array());
-        $this->assertEquals(1, $res);
+        $exitCode = $this->execute(array('target' => 'Builder 1', '--keep-exit-code' => true), array());
+        $this->assertEquals(1, $exitCode);
     }
 
     public function testBuildNotTarget()


### PR DESCRIPTION
If a job in the list fails the build command still returns 0 as if nothing happens. This might not be the correct behavior. In our example we have a build job that builds the assets but if the asset building fails then the builder still returns 0. Which is not true.

## Steps to reproduce
* Define a builder that fails with exit code 255.
* Run the build command
* Build command will return with exit code zero.

## Expected behavior
There should be a way to retrieve if the pipeline run was successful or not.

## How to solve
I have added an option -e to keep the exit code of the last failing job. As the interface doesn't define `void` explicitly we don't need to change anything.