### PR TITLE
Allow installation with symfony 6 remove support for PHP 7.3 and lower

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -16,13 +16,8 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - php-version: '7.2'
-                      dependency-versions: 'lowest'
-                      tools: 'composer:v1'
-                      php-cs-fixer: false
-
                     - php-version: '7.4'
-                      dependency-versions: 'highest'
+                      dependency-versions: 'lowest'
                       tools: 'composer:v2'
                       php-cs-fixer: false
 

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -24,6 +24,16 @@ jobs:
                     - php-version: '7.4'
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
+                      php-cs-fixer: false
+
+                    - php-version: '8.0'
+                      dependency-versions: 'highest'
+                      tools: 'composer:v2'
+                      php-cs-fixer: false
+
+                    - php-version: '8.1'
+                      dependency-versions: 'highest'
+                      tools: 'composer:v2'
                       php-cs-fixer: true
 
         steps:

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -16,8 +16,13 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - php-version: '7.4'
+                    - php-version: '7.2'
                       dependency-versions: 'lowest'
+                      tools: 'composer:v1'
+                      php-cs-fixer: false
+
+                    - php-version: '7.4'
+                      dependency-versions: 'highest'
                       tools: 'composer:v2'
                       php-cs-fixer: false
 

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -12,8 +12,8 @@ EOF;
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__);
 
-return PhpCsFixer\Config::create()
-    ->setRiskyAllowed(true)
+$config = new PhpCsFixer\Config();
+$config->setRiskyAllowed(true)
     ->setRules([
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
@@ -23,11 +23,14 @@ return PhpCsFixer\Config::create()
         'header_comment' => ['header' => $header],
         'native_constant_invocation' => true,
         'native_function_casing' => true,
-        'native_function_invocation' => true,
+        'native_function_invocation' => ['include' => ['@internal']],
         'no_superfluous_phpdoc_tags' => ['allow_mixed' => true, 'remove_inheritdoc' => true],
         'ordered_imports' => true,
         'phpdoc_align' => ['align' => 'left'],
         'phpdoc_types_order' => false,
         'single_line_throw' => false,
+        'single_line_comment_spacing' => false,
     ])
     ->setFinder($finder);
+
+return $config;

--- a/Console/MassiveOutputFormatter.php
+++ b/Console/MassiveOutputFormatter.php
@@ -33,7 +33,7 @@ class MassiveOutputFormatter extends OutputFormatter
         $this->indentLevel = $level;
     }
 
-    public function format(?string $message): ?string
+    public function format($message): ?string
     {
         $out = parent::format($message);
         if (!$this->isDecorated()) {

--- a/Console/MassiveOutputFormatter.php
+++ b/Console/MassiveOutputFormatter.php
@@ -33,7 +33,7 @@ class MassiveOutputFormatter extends OutputFormatter
         $this->indentLevel = $level;
     }
 
-    public function format($message)
+    public function format(?string $message): ?string
     {
         $out = parent::format($message);
         if (!$this->isDecorated()) {

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
     "license": "MIT",
     "require": {
         "php": ">=7.2.0",
-        "symfony/console": "^4.3 || ^5.0",
-        "symfony/config": "^4.3 || ^5.0",
-        "symfony/dependency-injection": "^4.3 || ^5.0",
-        "symfony/framework-bundle": "^4.3 || ^5.0"
+        "symfony/console": "^4.3 || ^5.0 || ^6.0",
+        "symfony/config": "^4.3 || ^5.0 || ^6.0",
+        "symfony/dependency-injection": "^4.3 || ^5.0 || ^6.0",
+        "symfony/framework-bundle": "^4.3 || ^5.0 || ^6.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^5.0.4",
+        "symfony/phpunit-bridge": "^5.0.4 || ^6.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=7.4",
+        "php": ">=7.2.0",
         "symfony/console": "^4.3 || ^5.0 || ^6.0",
         "symfony/config": "^4.3 || ^5.0 || ^6.0",
         "symfony/dependency-injection": "^4.3 || ^5.0 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.4",
         "symfony/console": "^4.3 || ^5.0 || ^6.0",
         "symfony/config": "^4.3 || ^5.0 || ^6.0",
         "symfony/dependency-injection": "^4.3 || ^5.0 || ^6.0",


### PR DESCRIPTION
This will allow installation with symfony 6.