### PR TITLE
Updated example for custom build targets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ You can define new build targets in you applications configuration file:
 massive_build:
     targets:
         main:
-            target_one: ~
-            target_two: ~
-            target_three: ~
+            dependencies:
+                target_one: ~
+                target_two: ~
+                target_three: ~
         quick:
-            target_one: ~
+            dependencies:
+                target_one: ~
 ````
 
 The above will allow you to execute:


### PR DESCRIPTION
The example misses the  level in the config.

```yaml
massive_build:
    targets:
        main:
            target_one: ~
            target_two: ~
            target_three: ~
        quick:
            target_one: ~
```

Should be written as 
```yaml
massive_build:
    targets:
        main:
            dependencies:
                target_one: ~
                target_two: ~
                target_three: ~
        quick:
            dependencies:
                target_one: ~
```