### PR TITLE
Fix bc break in Build Command

### DIFF
--- a/Command/BuildCommand.php
+++ b/Command/BuildCommand.php
@@ -27,9 +27,6 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface as SymfonyContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-/**
- * @final
- */
 class BuildCommand extends Command
 {
     /**
@@ -65,7 +62,7 @@ class BuildCommand extends Command
         $this->question = new QuestionHelper();
     }
 
-    public function configure(): void
+    public function configure()
     {
         $this->setName('massive:build');
         $this->setDescription('Execute build or build targets');


### PR DESCRIPTION
See https://github.com/sulu/sulu/blob/d635d8dcaa8679c4ff5ab3f1f52a6fa7ea3bc53a/src/Sulu/Bundle/CoreBundle/CommandOptional/SuluBuildCommand.php#L25

Symfony only require return type for execut: https://github.com/symfony/symfony/blob/695bd1a93c0f99db31f8bb4f424165eb7947faa0/src/Symfony/Component/Console/Command/Command.php#L165