### PR TITLE
Add better error message when target does not exist

### DIFF
--- a/Build/BuildRegistry.php
+++ b/Build/BuildRegistry.php
@@ -54,8 +54,7 @@ class BuildRegistry
 
     protected function getBuildersForTarget($target, &$list = [], &$resolved = [])
     {
-        $builders = [];
-        $builder = $this->builders[$target];
+        $builder = $this->getBuilder($target);
         $dependencies = $builder->getDependencies();
 
         foreach ($dependencies as $dependency) {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/c57eca2b-1011-49ef-9f9d-f752bcb82318)

Now:
![image](https://github.com/user-attachments/assets/cbbc53ec-df6f-4578-8b2a-dd38ace26b5d)

How to reproduce:
Run `bin/console sulu:build non-existing-builder`